### PR TITLE
First fully workable version of Instantiator is added.

### DIFF
--- a/src/RS/DependencyHandler/Instantiator.php
+++ b/src/RS/DependencyHandler/Instantiator.php
@@ -3,10 +3,76 @@
 namespace RS\DependencyHandler;
 
 
-class Instantiator implements InstantiatorInterface
+abstract class Instantiator implements InstantiatorInterface
 {
-    public static function get()
+    private static $store;
+    private static $cache;
+    
+    private static function called_class()
     {
-        
+        return get_called_class();
+    }
+
+    private static function &store()
+    {
+        if(self::$store === null) {
+            self::$store = [];
+            self::called_class()::instantiates();
+        }
+        return self::$store;
+    }
+
+    private static function &cache()
+    {
+        if(self::$cache === null) {
+            self::$cache = [];
+        }
+        return self::$cache;
+    }
+
+    public static function add($trigger, $builder)
+    {
+        if(isset(self::store()[$trigger])) {
+            throw new \Exception(
+                $trigger . " already exists in " . self::called_class(),
+                1
+            );
+        }
+        self::store()[$trigger] = [
+            "class" => $builder[0],
+            "method" => $builder[1]
+        ];
+    }
+
+    public static function addOrOverwrite($trigger, $builder)
+    {
+        self::store()[$trigger] = [
+            "class" => $builder[0],
+            "method" => $builder[1]
+        ];
+        unset(self::cache()[$trigger]);
+    }
+
+    public static function get($trigger, ...$args)
+    {
+        if(!isset(self::store()[$trigger])) {
+            throw new \Exception(
+                "No such class named " . $trigger . " registered in " . self::called_class(),
+                1
+            );
+        }
+        if(!isset(self::cache()[$trigger])) {
+            $builder = self::store()[$trigger]["class"];
+            self::cache()[$trigger] = new $builder();
+        }
+        return self::cache()[$trigger]->{
+            self::store()[$trigger]["method"]
+        }(...$args);
+    }
+
+    public static function flush()
+    {
+        self::$store = null;
+        self::$cache = null;
     }
 }

--- a/src/RS/DependencyHandler/InstantiatorInterface.php
+++ b/src/RS/DependencyHandler/InstantiatorInterface.php
@@ -5,5 +5,9 @@ namespace RS\DependencyHandler;
 
 interface InstantiatorInterface
 {
-    public static function get();
+    public static function add($trigger, $builder);
+    public static function addOrOverwrite($trigger, $builder);
+    public static function instantiates();
+    public static function get($trigger, ...$args);
+    public static function flush();
 }

--- a/tests/RS/DependencyHandler/InstantiatorTest.php
+++ b/tests/RS/DependencyHandler/InstantiatorTest.php
@@ -8,11 +8,184 @@ use RS\DependencyHandler\InstantiatorInterface;
 use RS\DependencyHandler\Instantiator;
 
 
+// basic classes
+
+class Singleton {
+    public function says() {
+        return "singleton";
+    }
+}
+
+
+class Speaker
+{
+    private $name;
+    private $speech;
+
+    public function __construct($name, $speech=null)
+    {
+        $this->name = $name;
+        if($speech === null) {
+            $speech = "Hello, World!";
+        }
+        $this->speech = $speech;
+    }
+
+    public function getName() {
+        return $this->name;
+    }
+
+    public function speaks()
+    {
+        return $this->speech;
+    }
+}
+
+
+class Presenter
+{
+    private $name;
+    private $act;
+
+    public function __construct($name, $act=null)
+    {
+        $this->name = $name;
+        if($act === null) {
+            $act = "The greatest show on earth";
+        }
+        $this->act = $act;
+    }
+
+    public function getName() {
+        return $this->name;
+    }
+
+    public function presents()
+    {
+        return $this->act;
+    }
+}
+
+
+// builder classes
+
+class SingletonBuilder
+{
+    private $instance;
+
+    final public function build()
+    {
+        if($this->instance === null) {
+            $this->instance = new Singleton();
+        }
+        return $this->instance;
+    }
+}
+
+
+class SpeakerBuilder {
+    public function build($name, $speech=null)
+    {
+        return new Speaker($name, $speech);
+    }
+}
+
+
+class PresenterBuilder {
+    public function build($name, $act=null)
+    {
+        return new Presenter($name, $act);
+    }
+}
+
+
+// instantiator
+
+class SomeInstantiator extends Instantiator
+{
+    public static function instantiates()
+    {
+        self::add("speaker", [SpeakerBuilder::class, "build"]);
+    }
+}
+
+
+// test instantiator
+
 class InstantiatorTest extends TestCase
 {
     public function testInterface()
     {
-        $instantiator = new Instantiator();
+        $instantiator = new SomeInstantiator();
         $this->assertTrue($instantiator instanceof InstantiatorInterface);
+    }
+
+    public function testGet()
+    {
+        SomeInstantiator::flush();
+        // add instantiators
+        // also note: "speaker" instantiator is already added
+        //            using the instantiates method
+        SomeInstantiator::add("singleton", [SingletonBuilder::class, "build"]);
+
+        $singleton = SomeInstantiator::get(
+            "singleton"
+        );
+        $this->assertTrue($singleton instanceof Singleton);
+        $this->assertEquals($singleton->says(), "singleton");
+        
+        $speaker = SomeInstantiator::get(
+            "speaker",
+            "reyad"
+        );
+        $this->assertTrue($speaker instanceof Speaker);
+        $this->assertEquals($speaker->getName(), "reyad");
+
+        $speaker = SomeInstantiator::get(
+            "speaker",
+            "reyad",
+            "We're seeking for peace!"
+        );
+        $this->assertEquals($speaker->getName(), "reyad");
+        $this->assertEquals($speaker->speaks(), "We're seeking for peace!");
+
+        $speaker = SomeInstantiator::get(
+            "speaker",
+            "jen",
+            "What a nice day!"
+        );
+        $this->assertEquals($speaker->getName(), "jen");
+        $this->assertEquals($speaker->speaks(), "What a nice day!");
+    }
+
+    public function testAddOrOverwrite() {
+        SomeInstantiator::flush();
+
+        SomeInstantiator::add(
+            "singleton",
+            [SingletonBuilder::class, "build"]
+        );
+        $singleton = SomeInstantiator::get(
+            "singleton"
+        );
+        $this->assertTrue($singleton instanceof Singleton);
+        $this->assertEquals($singleton->says(), "singleton");
+        
+
+        // overwriting "singleton" by "speaker" class
+        // a "speaker" object will be built by "singleton" trigger
+        // so, basically what we're doing is
+        //     we're creating a "speaker" class using
+        //     the singleton trigger
+        SomeInstantiator::addOrOverwrite(
+            "singleton",
+            [SpeakerBuilder::class, "build"]
+        );
+        $speaker = SomeInstantiator::get(
+            "singleton",
+            "reyad"
+        );
+        $this->assertTrue($speaker instanceof Speaker);
+        $this->assertEquals($speaker->getName(), "reyad");
     }
 }


### PR DESCRIPTION
Notes:
 - Instantiator implements InstantiatorInterface
 - all variables of Instantiator are static
 - all methods of Instantiator are static

The functionalities(i.e. public methods) added to Instantiator are:

 - Instantiator::add($trigger, $builder) : It takes a trigger string
 and an array(and the array consists of a builder class name and
 method) as input. If trigger already exists, then throws exception

 - Instantiator::addOrOverwrite($trigger, $builder) : This is basically
 same as add method, as add method does not support overwrite, this
 method is provided for both overwrite or add if match not found

 - Instantiator::instantiates() : This method is used for registering
 builder class for corresponding triggers. Instantiator is an abstract
 class, and it does not implement instantiates method, so, it is the
 classes reponsibility which extends Instantiator to provide implements
 for instantiates method

 - Instantiator::get($trigger, ...$args): It returns an object which is
 produced by the provided trigger. If trigger does not exists, then
 throws exception

 - Instantiator::flush(): It removes all stored triggers and
 corresponding builders. Also, clears cache of created builder objects

Also, this commit holds all the changes of private variables and
private methods which were necessary to provided the functionalities
which have been discussed above